### PR TITLE
Implements persisting of entrant data and editing user profile

### DIFF
--- a/code/app/src/main/java/com/example/trojanplanner/ProfileUtils/ProfileFragment.java
+++ b/code/app/src/main/java/com/example/trojanplanner/ProfileUtils/ProfileFragment.java
@@ -1,6 +1,10 @@
 package com.example.trojanplanner.ProfileUtils;
 
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.os.Bundle;
+import android.provider.ContactsContract;
+import android.provider.Settings;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,16 +17,31 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
+import com.example.trojanplanner.App;
 import com.example.trojanplanner.R;
+import com.example.trojanplanner.model.Database;
+import com.example.trojanplanner.model.Entrant;
+import com.example.trojanplanner.model.User;
 
 public class ProfileFragment extends Fragment {
 
+    private Database database;
+    
     private ImageView profileImage;
-    private EditText usernameInput, emailInput, phoneInput, cityInput, passwordInput;
-    private Spinner countrySpinner;
+    private EditText firstNameInput, lastNameInput, emailInput, phoneInput;
+    private boolean changedPfp = false;
+
+    private User user;
 
     public ProfileFragment() {
         // Required empty public constructor
+    }
+
+    public ProfileFragment(User user) {
+        this.user = user;
+        if (database == null) {
+            database = new Database();
+        }
     }
 
     @Nullable
@@ -32,12 +51,10 @@ public class ProfileFragment extends Fragment {
 
         // Initialize views
         profileImage = view.findViewById(R.id.profile_image);
-        usernameInput = view.findViewById(R.id.username_input);
+        firstNameInput = view.findViewById(R.id.firstname_input);
+        lastNameInput = view.findViewById(R.id.lastname_input);
         emailInput = view.findViewById(R.id.email_input);
         phoneInput = view.findViewById(R.id.phone_input);
-        cityInput = view.findViewById(R.id.city_input);
-        countrySpinner = view.findViewById(R.id.country_spinner);
-        passwordInput = view.findViewById(R.id.password_input);
 
         Button cancelButton = view.findViewById(R.id.cancel_button);
         Button saveButton = view.findViewById(R.id.save_button);
@@ -51,9 +68,102 @@ public class ProfileFragment extends Fragment {
 
     private void handleCancel() {
         // Handle cancel action, e.g., clear fields or go back
+        System.out.println("Cancel!");
+        System.out.println("user: " + user);
+        if (user != null) {
+            System.out.println("firstname: " + user.getFirstName() + ", lastname: " + user.getLastName());
+        }
+        populateFields(user); // for now, reset fields to current saved values
     }
 
     private void handleSave() {
         // Handle save action, e.g., validate input and save to a database or API
+        System.out.println("Save!");
+
+        // Input validation
+        boolean errorCaught = false;
+        String firstName = firstNameInput.getText().toString();
+        if (firstName.isEmpty()) {
+            firstNameInput.setError("First name cannot be empty.");
+            errorCaught = true;
+        }
+        String lastName = lastNameInput.getText().toString();
+        if (lastName.isEmpty()) {
+            lastNameInput.setError("Last name cannot be empty.");
+            errorCaught = true;
+        }
+        String email = emailInput.getText().toString();
+        if (email.isEmpty()) {
+            emailInput.setError("Email cannot be empty.");
+            errorCaught = true;
+        }
+        String phone = phoneInput.getText().toString();
+
+        // Do not upload if error was caught
+        if (errorCaught) {
+            return;
+        }
+
+        // If currentUser is not null, we will retain some of their other attributes.
+        // If null, give basic entrant privileges
+        boolean isOrganizer = false, isAdmin = false;
+        String deviceId;
+        if (user != null) {
+            user.setFirstName(firstName);
+            user.setLastName(lastName);
+            user.setEmail(email);
+            user.setPhoneNumber(phone);
+            deviceId = user.getDeviceId();
+        }
+        else {
+            deviceId = Settings.Secure.getString(App.activityManager.getActivity().getContentResolver(), Settings.Secure.ANDROID_ID);
+            user = new Entrant(lastName, firstName, email, phone, deviceId, "Entrant", false, false);
+        }
+
+        if (database == null) {
+            database = new Database();
+        }
+
+        // If pfp image was changed, explicitly choose a new filepath here
+        // and use it for both the Firebase Storage upload and the database document insert
+        if (changedPfp) {
+            Bitmap bitmap = null; // TODO do it
+            String newPfpFilepath = deviceId + "/" + System.currentTimeMillis() + ".png";
+            user.setPfpFilePath(newPfpFilepath);
+            database.uploadImage(bitmap, user, newPfpFilepath); // assume this doesn't fail??
+        }
+
+        // Upload
+        database.insertUserDocument(user);
     }
+
+    /**
+     *
+     * @param user
+     * @author Jared Gourley
+     */
+    public void populateFields(User user) {
+        // TODO: there's a bug here? if the user opens the app and switches to this tab before the initial query comes back, these fields don't populate (since user is still null)
+        String firstName = "", lastName = "", email = "", phone = "";
+        if (user != null) {
+            if (user.getFirstName() != null) {
+                firstName = user.getFirstName();
+            }
+            if (user.getLastName() != null) {
+                lastName = user.getLastName();
+            }
+            if (user.getEmail() != null) {
+                email = user.getEmail();
+            }
+            if (user.getPhoneNumber() != null) {
+                phone = user.getPhoneNumber();
+            }
+        }
+        firstNameInput.setText(firstName);
+        lastNameInput.setText(lastName);
+        emailInput.setText(email);
+        phoneInput.setText(phone);
+    }
+    
+    
 }

--- a/code/app/src/main/java/com/example/trojanplanner/controller/PhotoPicker.java
+++ b/code/app/src/main/java/com/example/trojanplanner/controller/PhotoPicker.java
@@ -2,7 +2,9 @@ package com.example.trojanplanner.controller;
 
 
 import android.app.Activity;
+import android.graphics.Bitmap;
 import android.net.Uri;
+import android.provider.MediaStore;
 import android.util.Log;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -15,6 +17,8 @@ import androidx.lifecycle.LifecycleOwner;
 import com.example.trojanplanner.App;
 import com.example.trojanplanner.model.Database;
 import com.example.trojanplanner.model.User;
+
+import java.io.IOException;
 
 /**
  * Class that provides the ability to open the user's photo library and select a photo
@@ -74,8 +78,16 @@ public class PhotoPicker {
                     if (uri != null) {
                         Log.d("PhotoPicker", "Selected URI: " + uri);
                         selectedPhoto = uri;
+                        Bitmap bitmap;
                         if (database != null) {
-                            database.uploadImage(uri, user);
+                            try {
+                                bitmap = MediaStore.Images.Media.getBitmap(activity.getContentResolver(), uri);
+                            }
+                            catch (IOException e) {
+                                System.out.println("uri invalid/no permissions");
+                                return;
+                            }
+                            database.uploadImage(bitmap, user);
                         }
                         currentlyPicking = false;
                     } else {

--- a/code/app/src/main/java/com/example/trojanplanner/model/User.java
+++ b/code/app/src/main/java/com/example/trojanplanner/model/User.java
@@ -2,11 +2,13 @@ package com.example.trojanplanner.model;
 import android.graphics.Bitmap;
 import android.provider.Settings;
 
+import java.io.Serializable;
+
 /**
  * user class contains and stores information tied to a user.
  * @author Madelaine Dalangin
  */
-public abstract class User {
+public abstract class User implements Serializable {
     private String lastName;
     private String firstName;
     private String email;
@@ -41,27 +43,6 @@ public abstract class User {
         this.isAdmin = isAdmin;
     }
 
-    /**
-     * User method using deviceID differently
-     * @author Madelaine Dalangin
-     * @param lastName
-     * @param firstName
-     * @param email
-     * @param phoneNumber
-     * @param role
-     * @param isOrganizer
-     * @param isAdmin
-     */
-    public User(String lastName, String firstName, String email, String phoneNumber, String role, boolean isOrganizer, boolean isAdmin){
-        this.lastName = lastName;
-        this.firstName = firstName;
-        this.email = email;
-        this.phoneNumber = phoneNumber;
-        this.deviceId = Settings.Secure.ANDROID_ID;
-        this.role = role;
-        this.isOrganizer = isOrganizer;
-        this.isAdmin = isAdmin;
-    }
 
     /**
      * Getter method for user's last name

--- a/code/app/src/main/java/com/example/trojanplanner/view/MainActivity.java
+++ b/code/app/src/main/java/com/example/trojanplanner/view/MainActivity.java
@@ -7,10 +7,14 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.widget.Button;
+import android.widget.Toast;
 
+import com.example.trojanplanner.App;
 import com.example.trojanplanner.events.EmptyEventsFragment;
 import com.example.trojanplanner.events.EventsFragment;
 import com.example.trojanplanner.R;
+import com.example.trojanplanner.model.Database;
+import com.example.trojanplanner.model.Entrant;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -25,7 +29,11 @@ import java.util.Objects;
 
 public class MainActivity extends AppCompatActivity {
     private ActivityMainBinding binding;
-    private static Activity activity; // Important to allow non-activity classes to trigger UI components, i.e. PhotoPicker
+    private Activity activity;
+
+    private Entrant currentUser = null; // The person who is using the app right now
+    private String deviceId;
+    private Database database;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -34,15 +42,37 @@ public class MainActivity extends AppCompatActivity {
         binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        activity = this;
+        // Get information from other activity
+        if (getIntent().getExtras() != null) {
+            deviceId = getIntent().getExtras().getString("deviceId");
+            currentUser = (Entrant) getIntent().getExtras().getSerializable("user");
+        }
 
-        storeDeviceId();
+
+        activity = this;
+        database = new Database();
+
+        // If this is the first time opening the app, get the device ID
+        // If this device ID doesn't match a user on the db then force them to make a profile (switch to that activity)
+        if (deviceId == null) {
+            storeDeviceId();
+            System.out.println("deviceId: " + deviceId);
+
+            // Get/check entrant from db based on device ID (note: this is async)
+            getEntrantFromDeviceId(deviceId); // Redirects if no entrant exists!
+        }
+
 
         // Load EmptyEventsFragment initially
-        loadEmptyEventsFragment();
+        loadEmptyEventsFragment(); // TODO: In the getEntrantFromDeviceId OnSuccess operation, load actual events if entrant has them
 
         setupNavigation();
     }
+
+
+
+
+
 
     private void loadEmptyEventsFragment() {
         getSupportFragmentManager()
@@ -54,7 +84,8 @@ public class MainActivity extends AppCompatActivity {
     @SuppressLint("HardwareIds")
     private void storeDeviceId() {
         // Get the device ID
-         String deviceId = Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID);
+        String deviceId = Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID);
+        this.deviceId = deviceId;
 
         // Get SharedPreferences
         SharedPreferences sharedPreferences = getSharedPreferences("MyAppPreferences", MODE_PRIVATE);
@@ -64,6 +95,45 @@ public class MainActivity extends AppCompatActivity {
         editor.putString("device_id", deviceId);
         editor.apply(); // Save changes
     }
+
+    /**
+     *
+     * @param deviceId
+     * @author Jared Gourley
+     */
+    private void getEntrantFromDeviceId(String deviceId) {
+        // On success, set the entrant object and populate the events list
+        // On failure, redirect to the make profile page (for now?)
+        Database.QuerySuccessAction successAction = new Database.QuerySuccessAction(){
+            @Override
+             public void OnSuccess(Object object) {
+                 currentUser = (Entrant) object;
+                 System.out.println("getEntrantFromDeviceId success! current user: " + currentUser.getFirstName() + " " + currentUser.getLastName());
+                 Toast myToast = Toast.makeText(App.activityManager.getActivity(), "Hello " + currentUser.getFirstName() + "!", Toast.LENGTH_LONG);
+                 myToast.show();
+                 // TODO: populate events array
+             }
+        };
+        Database.QueryFailureAction failureAction = new Database.QueryFailureAction(){
+            @Override
+            public void OnFailure() {
+                System.out.println("getEntrantFromDeviceId failed: new user?");
+                Toast myToast = Toast.makeText(App.activityManager.getActivity(), "Hello new user! Make a profile to join events!", Toast.LENGTH_LONG);
+                myToast.show();
+                Intent intent = new Intent(MainActivity.this, ProfileActivity.class);
+                intent.putExtra("deviceId", deviceId);
+                intent.putExtra("user", currentUser);
+                startActivity(intent);
+            }
+        };
+
+        database.getEntrant(successAction, failureAction, deviceId);
+    }
+
+
+
+
+
 
     /**
      * Sets up the navigation for the BottomNavigationView and the ActionBar.
@@ -109,22 +179,20 @@ public class MainActivity extends AppCompatActivity {
                 navController.navigate(R.id.eventsFragment);
                 return true;
             } else if (item.getItemId() == R.id.qrActivity) {
-                startActivity(new Intent(MainActivity.this, QRActivity.class));
+                Intent intent = new Intent(MainActivity.this, QRActivity.class);
+                intent.putExtra("deviceId", deviceId);
+                intent.putExtra("user", currentUser);
+                startActivity(intent);
                 return true;
             } else if (item.getItemId() == R.id.profileActivity) {
-                startActivity(new Intent(MainActivity.this, ProfileActivity.class));
+                Intent intent = new Intent(MainActivity.this, ProfileActivity.class);
+                intent.putExtra("deviceId", deviceId);
+                intent.putExtra("user", currentUser);
+                startActivity(intent);
                 return true;
             }
             return false;
         });
     }
 
-    /*
-     * Gets the application context. This is a static method so any other class is able to call this function
-     * in order to get the application context itself
-     * @return The application context
-
-        public static Context getAppContext() {
-            return activity.getApplicationContext();
-        } */
 }

--- a/code/app/src/main/java/com/example/trojanplanner/view/ProfileActivity.java
+++ b/code/app/src/main/java/com/example/trojanplanner/view/ProfileActivity.java
@@ -2,6 +2,10 @@ package com.example.trojanplanner.view;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
@@ -9,10 +13,16 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.example.trojanplanner.ProfileUtils.ProfileFragment;
 import com.example.trojanplanner.R;
 import com.example.trojanplanner.databinding.ActivityProfileBinding;
+import com.example.trojanplanner.model.Entrant;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 public class ProfileActivity extends AppCompatActivity {
     private @NonNull ActivityProfileBinding binding;
+
+    private String deviceId;
+    private Entrant currentUser;
+
+    ProfileFragment profileFragment;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -21,16 +31,37 @@ public class ProfileActivity extends AppCompatActivity {
         binding = ActivityProfileBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        // Get information from the intent received from activity switch
+        deviceId = getIntent().getExtras().getString("deviceId");
+        currentUser = (Entrant) getIntent().getExtras().getSerializable("user");
+        assert deviceId != null;
+        System.out.println("deviceId: " + deviceId);
+        System.out.println("currentUser: " + currentUser);
+
+
         // Display ProfileFragment in the fragment container
         if (savedInstanceState == null) {
+            profileFragment = new ProfileFragment(currentUser);
             getSupportFragmentManager()
                     .beginTransaction()
-                    .replace(R.id.profile_fragment_container, new ProfileFragment())
+                    .replace(R.id.profile_fragment_container, profileFragment)
                     .commit();
         }
 
+
         setupNavigation();
+
+        // Future code will be written in onStart to make sure the fragment fully loads properly
+
     }
+
+    // Call future things from here because in onCreate the fragment container is not fully set up yet
+    @Override
+    protected void onStart() {
+        super.onStart();
+        profileFragment.populateFields(currentUser);
+    }
+
 
     /**
      * Sets up the navigation for the BottomNavigationView.
@@ -54,14 +85,25 @@ public class ProfileActivity extends AppCompatActivity {
         // Set the selected item to profileActivity
         navView.setSelectedItemId(R.id.profileActivity);
 
+        // Don't enable the click listener until valid profile is made
+        if (currentUser == null) {
+            return;
+        }
+
         // Set up the listener to handle Bottom Navigation item selections
         navView.setOnItemSelectedListener(item -> {
             if (item.getItemId() == R.id.navigation_home) {
-                startActivity(new Intent(ProfileActivity.this, MainActivity.class));
+                Intent intent = new Intent(ProfileActivity.this, MainActivity.class);
+                intent.putExtra("deviceId", deviceId);
+                intent.putExtra("user", currentUser);
+                startActivity(intent);
                 finish();
                 return true;
             } else if (item.getItemId() == R.id.qrActivity) {
-                startActivity(new Intent(ProfileActivity.this, QRActivity.class));
+                Intent intent = new Intent(ProfileActivity.this, QRActivity.class);
+                intent.putExtra("deviceId", deviceId);
+                intent.putExtra("user", currentUser);
+                startActivity(intent);
                 finish();
                 return true;
             } else return item.getItemId() == R.id.profileActivity; // Stay in the same activity

--- a/code/app/src/main/java/com/example/trojanplanner/view/QRActivity.java
+++ b/code/app/src/main/java/com/example/trojanplanner/view/QRActivity.java
@@ -17,6 +17,7 @@ import androidx.core.content.ContextCompat;
 import com.example.trojanplanner.QRUtils.QRHelpFragment;
 import com.example.trojanplanner.R;
 import com.example.trojanplanner.databinding.ActivityQrBinding;
+import com.example.trojanplanner.model.Entrant;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.Result;
@@ -44,12 +45,19 @@ public class QRActivity extends AppCompatActivity {
     private EditText etInput;
     private @NonNull ActivityQrBinding binding;
 
+    private String deviceId;
+    private Entrant currentUser;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         binding = ActivityQrBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        deviceId = getIntent().getExtras().getString("deviceId");
+        currentUser = (Entrant) getIntent().getExtras().getSerializable("user");
+
 
         barcodeView = findViewById(R.id.barcode_scanner);
         ImageButton helpButton = findViewById(R.id.qr_help_button);
@@ -168,11 +176,17 @@ public class QRActivity extends AppCompatActivity {
 
         navView.setOnItemSelectedListener(item -> {
             if (item.getItemId() == R.id.navigation_home) {
-                startActivity(new Intent(QRActivity.this, MainActivity.class));
+                Intent intent = new Intent(QRActivity.this, MainActivity.class);
+                intent.putExtra("deviceId", deviceId);
+                intent.putExtra("user", currentUser);
+                startActivity(intent);
                 finish();
                 return true;
             } else if (item.getItemId() == R.id.profileActivity) {
-                startActivity(new Intent(QRActivity.this, ProfileActivity.class));
+                Intent intent = new Intent(QRActivity.this, ProfileActivity.class);
+                intent.putExtra("deviceId", deviceId);
+                intent.putExtra("user", currentUser);
+                startActivity(intent);
                 finish();
                 return true;
             } else return item.getItemId() == R.id.qrActivity;

--- a/code/app/src/main/res/layout/fragment_profile.xml
+++ b/code/app/src/main/res/layout/fragment_profile.xml
@@ -26,20 +26,20 @@
         android:id="@+id/email_input"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="8dp"
         android:hint="Email"
         android:inputType="textEmailAddress"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/username_input" />
+        app:layout_constraintTop_toBottomOf="@id/lastname_input" />
 
     <EditText
-        android:id="@+id/username_input"
+        android:id="@+id/firstname_input"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="46dp"
-        android:hint="Username"
+        android:hint="First Name"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
@@ -49,8 +49,8 @@
         android:id="@+id/phone_input"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:hint="Phone Number"
+        android:layout_marginTop="8dp"
+        android:hint="Phone Number (Optional)"
         android:inputType="phone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
@@ -58,27 +58,15 @@
         app:layout_constraintTop_toBottomOf="@id/email_input" />
 
     <EditText
-        android:id="@+id/city_input"
+        android:id="@+id/lastname_input"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:hint="City/Province"
+        android:hint="Last Name"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/phone_input" />
-
-    <EditText
-        android:id="@+id/password_input"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:hint="Password"
-        android:inputType="textPassword"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/country_spinner" />
+        app:layout_constraintTop_toBottomOf="@+id/firstname_input" />
 
     <Button
         android:id="@+id/cancel_button"
@@ -91,7 +79,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/password_input" />
+        app:layout_constraintTop_toBottomOf="@+id/phone_input" />
 
     <Button
         android:id="@+id/save_button"
@@ -104,15 +92,5 @@
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/cancel_button" />
-
-    <Spinner
-        android:id="@+id/country_spinner"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/city_input" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
When app is launched, device ID is collected and immediately after a query is sent out to firestore to get the entrant document with that ID (this operation will only happen once per app use). 
- If failed, the user will be locked on the ProfileActivity screen until they successfully make a profile.
- If successful, they will start from the MainActivity like normal and can see their user information as well as edit it (changes will be updated in the database).

This completes user story 01.02.01, 01.02.02, and 01.07.01. I'd like to do 01.03.01 (upload profile picture) right away as well since I couldn't get to that.